### PR TITLE
Changes in the log level extractor and default severity level

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The two lambda functions reads the following configuration information from `con
     "TestFunction",
     "LoudFunction"
   ],
-  "logLevelExtractor": ".* - (error|warn|info|http|verbose|debug|silly): ",
+  "logLevelExtractor": ".* - (error|warn|info|verbose|debug|emerg|alert|crit|notice): ",
   "defaultLogLevel": "info"
 }
 ```

--- a/config/paperwatch.json
+++ b/config/paperwatch.json
@@ -13,6 +13,6 @@
     }
   ],
   "exclude": [],
-  "logLevelExtractor": ".* - (error|warn|info|http|verbose|debug|silly): ",
+  "logLevelExtractor": ".* - (error|warn|info|verbose|debug|emerg|alert|crit|notice): ",
   "defaultLogLevel": "info"
 }

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -14,6 +14,7 @@ exports.handler = function(event, context, callback){
 
     // Construct the winston transport for forwarding lambda logs to papertrail
     var papertrail = new winston.transports.Papertrail({
+      level: 'debug',
       host: config.host,
       port: config.port,
       hostname: "Lambda_" + data.owner + "_" + process.env.AWS_REGION,


### PR DESCRIPTION
In this PR we've made changes in the logLevelExtractor to support the log levels in RFC5424  as specified in the Winston 2.4.5 docs
[Supported log levels](https://www.npmjs.com/package/winston/v/2.4.5#logging-levels), and also increased severity level to maximum.