### PR TITLE
PaperWatch silly log level message handling

### DIFF
--- a/config/paperwatch.json
+++ b/config/paperwatch.json
@@ -13,6 +13,6 @@
     }
   ],
   "exclude": [],
-  "logLevelExtractor": ".* - (error|warn|info|verbose|debug|emerg|alert|crit|notice): ",
+  "logLevelExtractor": ".* - (error|warn|info|verbose|debug|emerg|alert|crit|notice|silly): ",
   "defaultLogLevel": "info"
 }

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -14,7 +14,7 @@ exports.handler = function(event, context, callback){
 
     // Construct the winston transport for forwarding lambda logs to papertrail
     var papertrail = new winston.transports.Papertrail({
-      level: 'debug',
+      level: 'silly',
       host: config.host,
       port: config.port,
       hostname: "Lambda_" + data.owner + "_" + process.env.AWS_REGION,


### PR DESCRIPTION
PaperWatch is now able to handle silly log level messages, by increasing the max severity level from "debug" -> "silly", before this change the silly log level was displayed as "info"(defaultLogLevel)  in Papertrail, now with these changes "silly" messages are going to be logged in Papertrail as "debug".