### PR TITLE
add control tower customization option to paperwatch so papertrail port and endpoint can be set by env vars

### DIFF
--- a/src/apiGateway.js
+++ b/src/apiGateway.js
@@ -51,10 +51,20 @@ function constructTransport(event, callback){
 
     program = program.join("_");
 
+    if(config.host == "<HOST NAME>"){
+    // use default paperwatch.json that is not set with papertrail host or port
+    // control tower customization deployment. host and port will be set as env variables
+        var paperTrailHost = process.env.PAPERTRAIL_HOST;
+        var paperTrailPort = process.env.PAPERTRAIL_PORT;
+    }else{
+        var paperTrailHost = config.host;
+        var paperTrailPort = config.port;
+    }
+
     // Construct the winston transport for forwarding lambda logs to papertrail
     var papertrail = new winston.transports.Papertrail({
-      host: config.host,
-      port: config.port,
+      host: paperTrailHost,
+      port: paperTrailPort,
       hostname: "API-Gateway_" + data.owner + "_" + process.env.AWS_REGION,
       program: program,
       logFormat: function(level, message){

--- a/src/ecs.js
+++ b/src/ecs.js
@@ -12,10 +12,20 @@ exports.handler = function(event, context, callback){
     if(err)
       return callback(err);
 
+    if(config.host == "<HOST NAME>"){
+    // use default paperwatch.json that is not set with papertrail host or port
+    // control tower customization deployment. host and port will be set as env variables
+        var paperTrailHost = process.env.PAPERTRAIL_HOST;
+        var paperTrailPort = process.env.PAPERTRAIL_PORT;
+    }else{
+        var paperTrailHost = config.host;
+        var paperTrailPort = config.port;
+    }
+
     // Construct the winston transport for forwarding ECS logs to papertrail
     var papertrail = new winston.transports.Papertrail({
-      host: config.host,
-      port: config.port,
+      host: paperTrailHost,
+      port: paperTrailPort,
       hostname: "ECS_" + data.owner + "_" + process.env.AWS_REGION,
       program: data.logGroup.split('/').pop(),
       logFormat: function(level, message){

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -12,11 +12,21 @@ exports.handler = function(event, context, callback){
     if(err)
       return callback(err);
 
+    if(config.host == "<HOST NAME>"){
+    // use default paperwatch.json that is not set with papertrail host or port
+    // control tower customization deployment. host and port will be set as env variables
+        var paperTrailHost = process.env.PAPERTRAIL_HOST;
+        var paperTrailPort = process.env.PAPERTRAIL_PORT;
+    }else{
+        var paperTrailHost = config.host;
+        var paperTrailPort = config.port;
+    }
+
     // Construct the winston transport for forwarding lambda logs to papertrail
     var papertrail = new winston.transports.Papertrail({
       level: 'silly',
-      host: config.host,
-      port: config.port,
+      host: paperTrailHost,
+      port: paperTrailPort,
       hostname: "Lambda_" + data.owner + "_" + process.env.AWS_REGION,
       program: data.logGroup.split('/').pop(),
       logFormat: function(level, message){


### PR DESCRIPTION
add control tower customization option to paperwatch so papertrail port and endpoint can be set by env vars